### PR TITLE
Don't reset the form when there are errors

### DIFF
--- a/assets/browserify/public.js
+++ b/assets/browserify/public.js
@@ -91,7 +91,9 @@ function createRequestHandler(formEl) {
                 }
 
                 // clear form
-                formEl.reset();
+                if (!response.error) {
+                    formEl.reset();
+                }
             } else {
                 // Server error :(
                 console.log(this.responseText);

--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -222,7 +222,9 @@ function createRequestHandler(formEl) {
                 }
 
                 // clear form
-                formEl.reset();
+                if (!response.error) {
+                    formEl.reset();
+                }
             } else {
                 // Server error :(
                 console.log(this.responseText);


### PR DESCRIPTION
Probably still had Gulp running, not sure if you prefer to get the processed `public.js` file(s) too?