### PR TITLE
Proposal: Allow variables in the forms, e.g. {{ user.email }} for default value

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -49,7 +49,7 @@ class Form {
         $html .= '<div class="hf-fields-wrap">';
         $html .= sprintf( '<input type="hidden" name="_hf_form_id" value="%d" />', $this->ID );
         $html .= sprintf( '<div style="display: none;"><input type="text" name="_hf_h%d" value="" /></div>', $this->ID );
-        $html .= $this->markup;
+        $html .= $this->get_markup();
         $html .= '<noscript>' . __( "Please enable JavaScript for this form to work.", 'html-forms' ) . '</noscript>';
         $html .= '</div>';
         $html .= '</form>';
@@ -113,6 +113,64 @@ class Form {
         */
         $message = apply_filters( 'hf_form_message_' . $code, $message, $form );
         return $message;
+    }
+
+    /**
+     * @return mixed|void
+     */
+    public function get_markup()
+    {
+        $markup = $this->markup_replace_variables( $this->markup );
+
+        return apply_filters( 'hf_form_markup', $markup, $this );
+    }
+
+    /**
+     * Replace variables.
+     *
+     * Replace variables in the form. For example you can set a default value in a email field like so:
+     * <input type="email" value="{{ user.email }}">
+     *
+     * Or if you want to pass on a default value:
+     * <input type="text" value="{{ user.name || John Doe }}">
+     *
+     * @param $markup
+     * @return mixed
+     */
+    private function markup_replace_variables( $markup ) {
+        $variable_replace = apply_filters( 'hf_form_markup_replace_variables', $variable_replace = $this->default_variable_replace(), $this );
+
+        $markup = preg_replace_callback( '/\{\{([^}]+)\}\}/', function( $matches ) use ( $variable_replace ) {
+            $default = '';
+            $variable = trim( $matches[1] );
+
+            if ( ( $default_pos = strpos( $variable, '||' ) ) !== false ) { // A fallback/default value has been set
+                $default = trim( substr( $variable, $default_pos +2 ) );
+                $variable = trim( substr( $variable, 0, $default_pos ) );
+            }
+
+            return isset( $variable_replace[ $variable ] ) ? $variable_replace[ $variable ] : $default;
+        }, $markup );
+
+        return $markup;
+    }
+
+    /**
+     * Default replaced variables.
+     *
+     * @return mixed
+     */
+    private function default_variable_replace() {
+        $variable_replace = array();
+        if ( is_user_logged_in() && $user = wp_get_current_user() ) {
+            $variable_replace['user.email'] = $user->user_email;
+            $variable_replace['user.first_name'] = $user->user_firstname;
+            $variable_replace['user.last_name'] = $user->user_lastname;
+            $variable_replace['user.login'] = $user->user_login;
+            $variable_replace['user.display_name'] = $user->display_name;
+        }
+
+        return $variable_replace;
     }
 
 }


### PR DESCRIPTION
This is a proposal to allow for certain variables within the form.
The most common use case will probably be to pre-fill certain fields for logged in users with contact forms. 

With this code you its possible to have variables like `{{ VARIABLE_NAME }}` and also `{{ VARIABLE_NAME || FALLBACK_VALUE }}`
For now I've added a few user based variables: https://github.com/ibericode/html-forms/compare/master...JeroenSormani:form-variables?expand=1#diff-2c77116739ece89c91385095c838f093R166

This of course can be extended through the filters.

![image](https://user-images.githubusercontent.com/5774447/33098340-613cd530-cf0d-11e7-8666-68928c413ec5.png)

Without entering anything:
![image](https://user-images.githubusercontent.com/5774447/33098373-7db007d2-cf0d-11e7-9a97-990331545617.png)

Let me know your thoughts!