### PR TITLE
Fix error in form preview when having wp_query related call

### DIFF
--- a/views/form-preview.php
+++ b/views/form-preview.php
@@ -3,6 +3,7 @@ defined( 'ABSPATH' ) or exit;
 
 // fake post to prevent notices in wp_enqueue_scripts call
 $GLOBALS['post'] = new \WP_Post((object) array( 'filter' => 'raw' ));
+$GLOBALS['wp_query'] = new \WP_Query();
 
 // render simple page with form in it.
 ?><!DOCTYPE html>


### PR DESCRIPTION
In the preview a error can occur when having a `$GLOBALS['wp_query']` related call in the wp_footer. 
`PHP Notice:  Trying to get property of non-object in /Users/jeroensormani/Sites/wp/wp-includes/class-wp-query.php on line 3871`

Reproducible by using the following code
```
add_action( 'wp_footer', function() {
	is_singular( 'page' );
} );
```