### PR TITLE
Save submissions

### DIFF
--- a/html-forms.php
+++ b/html-forms.php
@@ -42,6 +42,9 @@ function _bootstrap() {
     $email_action = new Actions\Email();
     $email_action->hook();
 
+    $save_action = new Actions\SaveSubmission();
+    $save_action->hook();
+
     if( is_admin() ) {
         if( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
             $admin = new Admin\Admin( __FILE__ );

--- a/html-forms.php
+++ b/html-forms.php
@@ -72,6 +72,7 @@ function _install() {
 }
 
 define( 'HTML_FORMS_VERSION', '1.1.4' );
+define( 'HTML_FORMS_FILE', __FILE__ );
 
 if( ! function_exists( 'hf_get_form' ) ) {
     require __DIR__ . '/vendor/autoload.php';

--- a/migrations/1.1.5-save-submission-action.php
+++ b/migrations/1.1.5-save-submission-action.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace HTML_Forms\Migrations;
+
+use HTML_Forms\Actions\SaveSubmission;
+use HTML_Forms\Forms;
+
+defined( 'ABSPATH' ) or exit;
+
+$settings = hf_get_settings();
+if ( ! empty( $settings['save_submissions'] ) ) {
+
+	$forms = new \WP_Query( array(
+		'post_type' => 'html-form',
+		'numberposts' => -1,
+		'update_post_post_cache' => false,
+		'update_post_term_cache' => false,
+		'no_found_rows' => true,
+
+	) );
+
+	// Update each form to add the 'Save' action
+	foreach ( $forms->get_posts() as $post ) {
+		$form = hf_get_form( $post->ID );
+
+		$settings = $form->settings;
+
+		if ( ! isset( $form->settings['actions'] ) ) {
+			$form->settings = array();
+		}
+
+		$form->settings['actions'][] = array(
+			'type' => 'save',
+		);
+
+		update_post_meta( $post->ID, '_hf_settings', $form->settings );
+	}
+
+	// Remove from settings
+	unset( $settings['save_submissions'] );
+	update_option( 'hf_settings', $settings );
+}

--- a/src/Actions/SaveSubmission.php
+++ b/src/Actions/SaveSubmission.php
@@ -29,8 +29,13 @@ class SaveSubmission extends Action {
    public function page_settings( $settings, $index ) {
        $settings = array_merge( $this->get_default_settings(), $settings );
 
-       // None (yet)
-   }
+       ?><input type="hidden" name="form[settings][actions][<?php echo $index; ?>][type]" value="<?php echo $this->type; ?>" />
+       <table class="form-table">
+           <tr>
+               <td colspan="2"><p class="description"><?php _e( 'This action has no settings', 'html-forms' ); ?></p></td>
+            </tr>
+       </table><?php
+}
 
     /**
      * Processes this action

--- a/src/Actions/SaveSubmission.php
+++ b/src/Actions/SaveSubmission.php
@@ -45,6 +45,6 @@ class SaveSubmission extends Action {
      * @param Form $form
      */
     public function process( array $settings, Submission $submission, Form $form ) {
-       $submission->save();
+       return $submission->save();
     }
 }

--- a/src/Actions/SaveSubmission.php
+++ b/src/Actions/SaveSubmission.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace HTML_Forms\Actions;
+
+use HTML_Forms\Form;
+use HTML_Forms\Submission;
+
+class SaveSubmission extends Action {
+
+   public $type = 'save';
+   public $label = 'Save submission';
+
+   public function __construct() {
+       $this->label = __( 'Save Submission', 'html-forms' );
+   }
+
+   /**
+   * @return array
+   */
+   private function get_default_settings() {
+       $defaults = array();
+       return $defaults;
+   }
+
+   /**
+   * @param array $settings
+   * @param string|int $index
+   */
+   public function page_settings( $settings, $index ) {
+       $settings = array_merge( $this->get_default_settings(), $settings );
+
+       // None (yet)
+   }
+
+    /**
+     * Processes this action
+     *
+     * @param array $settings
+     * @param Submission $submission
+     * @param Form $form
+     */
+    public function process( array $settings, Submission $submission, Form $form ) {
+       $submission->save();
+    }
+}

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -221,6 +221,12 @@ class Admin {
             )
         );
 
+        update_post_meta( $form_id, '_hf_settings', array(
+            'actions' => array(
+                array( 'type' => 'save' ),
+            )
+        ) );
+
         wp_safe_redirect( admin_url( 'admin.php?page=html-forms&view=edit&form_id=' . $form_id ));
         exit;
     }

--- a/src/Admin/Submission.php
+++ b/src/Admin/Submission.php
@@ -36,6 +36,8 @@ class Submission {
         if( $num_rows > 0 ) {
             $this->id = $wpdb->insert_id;
         }
+
+        return $this->id;
     }
 
     /**

--- a/src/Admin/Table.php
+++ b/src/Admin/Table.php
@@ -181,7 +181,9 @@ if( class_exists( 'WP_List_Table' ) ) {
                 'actions'       => __( 'Actions', 'html-forms' ),
             );
 
-            if( $this->settings['save_submissions'] ) {
+            $form = hf_get_form( $post->ID );
+            $action_types = wp_list_pluck( $form->settings['actions'], 'type' );
+            if( in_array( 'save', $action_types ) ) {
                 $tabs['submissions'] = __( 'Submissions', 'html-forms' );
             }
 

--- a/src/Forms.php
+++ b/src/Forms.php
@@ -178,7 +178,7 @@ class Forms
 
     /**
     * @return array
-    */ 
+    */
     public function get_request_data() {
         $data = $_POST;
 
@@ -243,10 +243,6 @@ class Forms
             * General purpose hook before the submission is saved, so we can still modify data that is (maybe) stored.
             */
             do_action( 'hf_process_form', $form, $submission );
-
-            if( $this->settings['save_submissions'] ) {
-                 $submission->save();
-            }
 
             // process form actions
             if ( isset( $form->settings['actions'] ) ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -115,7 +115,6 @@ function hf_get_form_submission( $submission_id ) {
 function hf_get_settings() {
     $default_settings = array(
         'load_stylesheet' => 0,
-        'save_submissions' => 1,
     );
 
     $settings = get_option( 'hf_settings', array() );

--- a/views/edit-form.php
+++ b/views/edit-form.php
@@ -7,7 +7,8 @@ $tabs = array(
     'actions'       => __( 'Actions', 'html-forms' ),
 );
 
-if( $settings['save_submissions'] ) {
+$action_types = wp_list_pluck( $form->settings['actions'], 'type' );
+if( in_array( 'save', $action_types ) ) {
     $tabs['submissions'] = __( 'Submissions', 'html-forms' );
 }
 

--- a/views/global-settings.php
+++ b/views/global-settings.php
@@ -9,8 +9,8 @@
     </p>
 
     <h1 class="page-title"><?php _e( 'Settings', 'html-forms' ); ?></h1>
-    
-     <?php if ( ! empty( $_GET['settings-updated'] ) ) { 
+
+     <?php if ( ! empty( $_GET['settings-updated'] ) ) {
         echo '<div class="notice notice-success"><p>' . __( 'Settings updated.', 'html-forms' ) . '</p></div>';
     } ?>
 
@@ -25,16 +25,6 @@
                         <label><input type="radio"  name="hf_settings[load_stylesheet]" value="0"  <?php checked( $settings['load_stylesheet'], 0 ); ?>> <?php _e( 'No' ); ?></label>
 
                         <p class="help"><?php _e( 'Select "yes" to apply some basic form styles to all HTML Forms.', 'html-forms' ); ?></p>
-                    </td>
-                </tr>
-
-                <tr valign="top">
-                    <th scope="row"><?php _e( 'Save form submissions?', 'html-forms' ); ?></th>
-                    <td>
-                        <label><input type="radio" name="hf_settings[save_submissions]" value="1" <?php checked( $settings['save_submissions'], 1 ); ?>> <?php _e( 'Yes' ); ?></label> &nbsp;
-                        <label><input type="radio"  name="hf_settings[save_submissions]" value="0"  <?php checked( $settings['save_submissions'], 0 ); ?>> <?php _e( 'No' ); ?></label>
-
-                        <p class="help"><?php _e( 'Select "yes" to store all successful form submissions.', 'html-forms' ); ?></p>
                     </td>
                 </tr>
 


### PR DESCRIPTION
Move the 'Save submissions' global setting to a per-form action. 
This is a nice improvement for the upcoming GDPR and overall flexibility of the plugin.

Includes migration to automatically add the action when the save submissions was set to 'yes'.

- Was also busy adding unit test(s), but I don't believe things are setup yet to do DB based tests, right?
- How do you utilize autoload? When I did a `$ composer dump-autoload` it changed a whole bunch of files that I didn't expect.. (so to test this PR you'd want to run that yourself)
