### PR TITLE
apply_filters() all the email action things

### DIFF
--- a/src/Actions/Email.php
+++ b/src/Actions/Email.php
@@ -101,10 +101,11 @@ class Email extends Action {
     $settings = array_merge( $this->get_default_settings(), $settings );
     $html_email = $settings['content_type'] === 'text/html';
 
-    $to = hf_replace_data_variables( $settings['to'], $submission->data, 'strip_tags' );
+    $to = apply_filters( 'hf_action_email_to', hf_replace_data_variables( $settings['to'], $submission->data, 'strip_tags' ), $submission );
     $subject = ! empty( $settings['subject'] ) ? hf_replace_data_variables( $settings['subject'], $submission->data, 'strip_tags' ) : '';
-    $message = hf_replace_data_variables( $settings['message'], $submission->data, $html_email ? null : 'strip_tags' );
-    
+    $subject = apply_filters( 'hf_action_email_subject', $subject, $submission );
+    $message = apply_filters( 'hf_action_email_message', hf_replace_data_variables( $settings['message'], $submission->data, $html_email ? null : 'strip_tags' ), $submission );
+
     // parse additional email headers from settings
     $headers = array();
     if( ! empty( $settings['headers'] ) ) {
@@ -116,7 +117,7 @@ class Email extends Action {
     }
 
     if( ! empty( $settings['from'] ) ) {
-      $from = hf_replace_data_variables($settings['from'], $submission->data, 'strip_tags');
+      $from = apply_filters( 'hf_action_email_from', hf_replace_data_variables( $settings['from'], $submission->data, 'strip_tags' ), $submission );
       $headers[] = sprintf( 'From: %s', $from );
     }
 


### PR DESCRIPTION
Per your request in  #61:

Tested the filtering locally to expected results. Didn't seem necessary to write actual unit tests since the functionality is so opt-in and really just core WP stuff?

Wasn't sure how you'd like to handle the subject filter since the subject definition is a ternary. I thought adding the filter as overwriting the variable read more clearly, but can one-line it or use different variable names or whatever else is your ultimate preference....

Debated whether or not to filter $message for a while, but I guess there's no harm and it's not hard to imagine some use cases.