### PR TITLE
introduce hf_get_admin_tabs and use it to get a filtered list of tabs

### DIFF
--- a/src/admin/class-table.php
+++ b/src/admin/class-table.php
@@ -7,263 +7,254 @@ use WP_List_Table, WP_Post;
 // Check if WP Core class exists so that we can keep testing rest of HTML Forms in isolation..
 if ( class_exists( 'WP_List_Table' ) ) {
 
-	class Table extends WP_List_Table {
+    class Table extends WP_List_Table {
 
-		/**
-		 * @var bool
-		 */
-		public $is_trash = false;
+        /**
+         * @var bool
+         */
+        public $is_trash = false;
 
-		/**
-		* @var array
-		*/
-		private $settings = array();
+        /**
+         * @var array
+         */
+        private $settings = array();
 
-		/**
-		 * Constructor
-		 */
-		public function __construct( array $settings ) {
-			parent::__construct(
-				array(
-					'singular' => 'form',
-					'plural'   => 'forms',
-					'ajax'     => false,
-				)
-			);
+        /**
+         * Constructor
+         */
+        public function __construct( array $settings ) {
+            parent::__construct(
+                array(
+                    'singular' => 'form',
+                    'plural'   => 'forms',
+                    'ajax'     => false,
+                )
+            );
 
-			$this->settings = $settings;
-			$this->process_bulk_action();
+            $this->settings = $settings;
+            $this->process_bulk_action();
 
-			$columns               = $this->get_columns();
-			$sortable              = $this->get_sortable_columns();
-			$hidden                = array();
-			$this->_column_headers = array( $columns, $hidden, $sortable );
-			$this->is_trash        = isset( $_REQUEST['post_status'] ) && $_REQUEST['post_status'] === 'trash';
-			$this->items           = $this->get_items();
-			$this->set_pagination_args(
-				array(
-					'per_page'    => 50,
-					'total_items' => count( $this->items ),
-				)
-			);
-		}
+            $columns               = $this->get_columns();
+            $sortable              = $this->get_sortable_columns();
+            $hidden                = array();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+            $this->is_trash        = isset( $_REQUEST['post_status'] ) && $_REQUEST['post_status'] === 'trash';
+            $this->items           = $this->get_items();
+            $this->set_pagination_args(
+                array(
+                    'per_page'    => 50,
+                    'total_items' => count( $this->items ),
+                )
+            );
+        }
 
-		/**
-		 * Get an associative array ( id => link ) with the list
-		 * of views available on this table.
-		 *
-		 * @since 3.1.0
-		 * @access protected
-		 *
-		 * @return array
-		 */
-		public function get_views() {
-			$counts    = wp_count_posts( 'html-form' );
-			$current   = isset( $_GET['post_status'] ) ? $_GET['post_status'] : '';
-			$count_any = $counts->publish + $counts->draft + $counts->future + $counts->pending;
+        /**
+         * Get an associative array ( id => link ) with the list
+         * of views available on this table.
+         *
+         * @since 3.1.0
+         * @access protected
+         *
+         * @return array
+         */
+        public function get_views() {
+            $counts    = wp_count_posts( 'html-form' );
+            $current   = isset( $_GET['post_status'] ) ? $_GET['post_status'] : '';
+            $count_any = $counts->publish + $counts->draft + $counts->future + $counts->pending;
 
-			return array(
-				''      => sprintf( '<a href="%s" class="%s">%s</a> (%d)', remove_query_arg( 'post_status' ), $current == '' ? 'current' : '', __( 'All', 'html-forms' ), $count_any ),
-				'trash' => sprintf( '<a href="%s" class="%s">%s</a> (%d)', add_query_arg( array( 'post_status' => 'trash' ) ), $current == 'trash' ? 'current' : '', __( 'Trash', 'html-forms' ), $counts->trash ),
-			);
-		}
+            return array(
+                ''      => sprintf( '<a href="%s" class="%s">%s</a> (%d)', remove_query_arg( 'post_status' ), $current == '' ? 'current' : '', __( 'All', 'html-forms' ), $count_any ),
+                'trash' => sprintf( '<a href="%s" class="%s">%s</a> (%d)', add_query_arg( array( 'post_status' => 'trash' ) ), $current == 'trash' ? 'current' : '', __( 'Trash', 'html-forms' ), $counts->trash ),
+            );
+        }
 
-		/**
-		 * @return array
-		 */
-		public function get_bulk_actions() {
+        /**
+         * @return array
+         */
+        public function get_bulk_actions() {
 
-			$actions = array();
+            $actions = array();
 
-			if ( $this->is_trash ) {
-				$actions['untrash'] = __( 'Restore', 'html-forms' );
-				$actions['delete']  = __( 'Delete Permanently', 'html-forms' );
-				return $actions;
-			}
+            if ( $this->is_trash ) {
+                $actions['untrash'] = __( 'Restore', 'html-forms' );
+                $actions['delete']  = __( 'Delete Permanently', 'html-forms' );
+                return $actions;
+            }
 
-			$actions['trash']     = __( 'Move to Trash', 'html-forms' );
-			$actions['duplicate'] = __( 'Duplicate', 'html-forms' );
-			return $actions;
-		}
+            $actions['trash']     = __( 'Move to Trash', 'html-forms' );
+            $actions['duplicate'] = __( 'Duplicate', 'html-forms' );
+            return $actions;
+        }
 
-		public function get_default_primary_column_name() {
-			return 'form_name';
-		}
+        public function get_default_primary_column_name() {
+            return 'form_name';
+        }
 
-		/**
-		 * @return array
-		 */
-		public function get_table_classes() {
-			return array( 'widefat', 'fixed', 'striped', 'html-forms-table' );
-		}
+        /**
+         * @return array
+         */
+        public function get_table_classes() {
+            return array( 'widefat', 'fixed', 'striped', 'html-forms-table' );
+        }
 
-		/**
-		 * @return array
-		 */
-		public function get_columns() {
-			return array(
-				'cb'        => '<input type="checkbox" />',
-				'form_name' => __( 'Form', 'html-forms' ),
-				'shortcode' => __( 'Shortcode', 'html-forms' ),
-			);
-		}
+        /**
+         * @return array
+         */
+        public function get_columns() {
+            return array(
+                'cb'        => '<input type="checkbox" />',
+                'form_name' => __( 'Form', 'html-forms' ),
+                'shortcode' => __( 'Shortcode', 'html-forms' ),
+            );
+        }
 
-		/**
-		 * @return array
-		 */
-		public function get_sortable_columns() {
-			return array();
-		}
+        /**
+         * @return array
+         */
+        public function get_sortable_columns() {
+            return array();
+        }
 
-		/**
-		 * @return array
-		 */
-		public function get_items() {
+        /**
+         * @return array
+         */
+        public function get_items() {
 
-			$args = array();
+            $args = array();
 
-			if ( ! empty( $_GET['s'] ) ) {
-				$args['s'] = sanitize_text_field( $_GET['s'] );
-			}
+            if ( ! empty( $_GET['s'] ) ) {
+                $args['s'] = sanitize_text_field( $_GET['s'] );
+            }
 
-			if ( ! empty( $_GET['post_status'] ) ) {
-				$args['post_status'] = sanitize_text_field( $_GET['post_status'] );
-			}
+            if ( ! empty( $_GET['post_status'] ) ) {
+                $args['post_status'] = sanitize_text_field( $_GET['post_status'] );
+            }
 
-			$items = hf_get_forms( $args );
-			return $items;
-		}
+            $items = hf_get_forms( $args );
+            return $items;
+        }
 
-		/**
-		 * @param Form $form
-		 * @return string
-		 */
-		public function column_cb( $form ) {
-			return sprintf( '<input type="checkbox" name="forms[]" value="%s" />', $form->ID );
-		}
+        /**
+         * @param Form $form
+         * @return string
+         */
+        public function column_cb( $form ) {
+            return sprintf( '<input type="checkbox" name="forms[]" value="%s" />', $form->ID );
+        }
 
-		/**
-		 * @param Form $form
-		 *
-		 * @return mixed
-		 */
-		public function column_ID( Form $form ) {
-			return $form->ID;
-		}
+        /**
+         * @param Form $form
+         *
+         * @return mixed
+         */
+        public function column_ID( Form $form ) {
+            return $form->ID;
+        }
 
-		/**
-		 * @param Form $form
-		 * @return string
-		 */
-		public function column_form_name( Form $form ) {
-			if ( $this->is_trash ) {
-				return sprintf( '<strong>%s</strong>', esc_html( $form->title ) );
-			}
+        /**
+         * @param Form $form
+         * @return string
+         */
+        public function column_form_name( Form $form ) {
+            if ( $this->is_trash ) {
+                return sprintf( '<strong>%s</strong>', esc_html( $form->title ) );
+            }
 
-			$edit_link = admin_url( 'admin.php?page=html-forms&view=edit&form_id=' . $form->ID );
-			$title     = '<strong><a class="row-title" href="' . $edit_link . '">' . esc_html( $form->title ) . '</a></strong>';
+            $edit_link = admin_url( 'admin.php?page=html-forms&view=edit&form_id=' . $form->ID );
+            $title     = '<strong><a class="row-title" href="' . $edit_link . '">' . esc_html( $form->title ) . '</a></strong>';
 
-			$actions = array();
-			$tabs    = array(
-				'fields'   => __( 'Fields', 'html-forms' ),
-				'messages' => __( 'Messages', 'html-forms' ),
-				'settings' => __( 'Settings', 'html-forms' ),
-				'actions'  => __( 'Actions', 'html-forms' ),
-			);
+            $actions = array();
+            $tabs = hf_get_admin_tabs($form);
 
-			if ( $form->settings['save_submissions'] ) {
-				$tabs['submissions'] = __( 'Submissions', 'html-forms' );
-			}
+            foreach ( $tabs as $tab_slug => $tab_title ) {
+                $actions[ $tab_slug ] = '<a href="' . esc_attr( add_query_arg( array( 'tab' => $tab_slug ), $edit_link ) ) . '">' . $tab_title . '</a>';
+            }
 
-			foreach ( $tabs as $tab_slug => $tab_title ) {
-				$actions[ $tab_slug ] = '<a href="' . esc_attr( add_query_arg( array( 'tab' => $tab_slug ), $edit_link ) ) . '">' . $tab_title . '</a>';
-			}
+            return $title . $this->row_actions( $actions );
+        }
 
-			return $title . $this->row_actions( $actions );
-		}
+        /**
+         * @param Form $form
+         * @return string
+         */
+        public function column_shortcode( Form $form ) {
+            if ( $this->is_trash ) {
+                return '';
+            }
 
-		/**
-		 * @param Form $form
-		 * @return string
-		 */
-		public function column_shortcode( Form $form ) {
-			if ( $this->is_trash ) {
-				return '';
-			}
+            return sprintf( '<input style="width: 260px;" type="text" onfocus="this.select();" readonly="readonly" value="%s">', esc_attr( '[hf_form slug="' . $form->slug . '"]' ) );
+        }
 
-			return sprintf( '<input style="width: 260px;" type="text" onfocus="this.select();" readonly="readonly" value="%s">', esc_attr( '[hf_form slug="' . $form->slug . '"]' ) );
-		}
+        /**
+         * The text that is shown when there are no items to show
+         */
+        public function no_items() {
+            echo sprintf( __( 'No forms found. <a href="%s">Would you like to create one now</a>?', 'html-forms' ), admin_url( 'admin.php?page=html-forms-add-form' ) );
+        }
 
-		/**
-		 * The text that is shown when there are no items to show
-		 */
-		public function no_items() {
-			echo sprintf( __( 'No forms found. <a href="%s">Would you like to create one now</a>?', 'html-forms' ), admin_url( 'admin.php?page=html-forms-add-form' ) );
-		}
+        /**
+         *
+         */
+        public function process_bulk_action() {
+            $action = $this->current_action();
+            if ( empty( $action ) ) {
+                return false;
+            }
 
-		/**
-		 *
-		 */
-		public function process_bulk_action() {
-			$action = $this->current_action();
-			if ( empty( $action ) ) {
-				return false;
-			}
+            $method = 'process_bulk_action_' . $action;
+            $forms  = (array) $_REQUEST['forms'];
+            if ( method_exists( $this, $method ) ) {
+                return call_user_func_array( array( $this, $method ), array( $forms ) );
+            }
 
-			$method = 'process_bulk_action_' . $action;
-			$forms  = (array) $_REQUEST['forms'];
-			if ( method_exists( $this, $method ) ) {
-				return call_user_func_array( array( $this, $method ), array( $forms ) );
-			}
+            return false;
+        }
 
-			return false;
-		}
+        public function process_bulk_action_duplicate( $forms ) {
+            foreach ( $forms as $form_id ) {
+                $post      = get_post( $form_id );
+                $post_meta = get_post_meta( $form_id );
 
-		public function process_bulk_action_duplicate( $forms ) {
-			foreach ( $forms as $form_id ) {
-				$post      = get_post( $form_id );
-				$post_meta = get_post_meta( $form_id );
+                $new_post_id = wp_insert_post(
+                    array(
+                        'post_title'   => $post->post_title,
+                        'post_content' => $post->post_content,
+                        'post_type'    => 'html-form',
+                        'post_status'  => 'publish',
+                    )
+                );
+                foreach ( $post_meta as $meta_key => $meta_value ) {
+                    $meta_value = maybe_unserialize( $meta_value[0] );
+                    update_post_meta( $new_post_id, $meta_key, $meta_value );
+                }
+            }
+        }
 
-				$new_post_id = wp_insert_post(
-					array(
-						'post_title'   => $post->post_title,
-						'post_content' => $post->post_content,
-						'post_type'    => 'html-form',
-						'post_status'  => 'publish',
-					)
-				);
-				foreach ( $post_meta as $meta_key => $meta_value ) {
-					$meta_value = maybe_unserialize( $meta_value[0] );
-					update_post_meta( $new_post_id, $meta_key, $meta_value );
-				}
-			}
-		}
+        public function process_bulk_action_trash( $forms ) {
+            return array_map( 'wp_trash_post', $forms );
+        }
 
-		public function process_bulk_action_trash( $forms ) {
-			return array_map( 'wp_trash_post', $forms );
-		}
+        public function process_bulk_action_delete( $forms ) {
+            return array_map( 'wp_delete_post', $forms );
+        }
 
-		public function process_bulk_action_delete( $forms ) {
-			return array_map( 'wp_delete_post', $forms );
-		}
+        public function process_bulk_action_untrash( $forms ) {
+            return array_map( 'wp_untrash_post', $forms );
+        }
 
-		public function process_bulk_action_untrash( $forms ) {
-			return array_map( 'wp_untrash_post', $forms );
-		}
+        /**
+         * Generates content for a single row of the table
+         *
+         * @since 3.1.0
+         *
+         * @param Form $form The current item
+         */
+        public function single_row( $form ) {
+            echo sprintf( '<tr id="hf-forms-item-%d">', $form->ID );
+            $this->single_row_columns( $form );
+            echo '</tr>';
+        }
 
-		/**
-		 * Generates content for a single row of the table
-		 *
-		 * @since 3.1.0
-		 *
-		 * @param Form $form The current item
-		 */
-		public function single_row( $form ) {
-			echo sprintf( '<tr id="hf-forms-item-%d">', $form->ID );
-			$this->single_row_columns( $form );
-			echo '</tr>';
-		}
-
-	}
+    }
 
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,18 +8,18 @@ use HTML_Forms\Submission;
  * @return array
  */
 function hf_get_forms( array $args = array() ) {
-	$default_args = array(
-		'post_type'           => 'html-form',
-		'post_status'         => array( 'publish', 'draft', 'pending', 'future' ),
-		'posts_per_page'      => -1,
-		'ignore_sticky_posts' => true,
-		'no_found_rows'       => true,
-	);
-	$args         = array_merge( $default_args, $args );
-	$query        = new WP_Query;
-	$posts        = $query->query( $args );
-	$forms        = array_map( 'hf_get_form', $posts );
-	return $forms;
+    $default_args = array(
+        'post_type'           => 'html-form',
+        'post_status'         => array( 'publish', 'draft', 'pending', 'future' ),
+        'posts_per_page'      => -1,
+        'ignore_sticky_posts' => true,
+        'no_found_rows'       => true,
+    );
+    $args         = array_merge( $default_args, $args );
+    $query        = new WP_Query;
+    $posts        = $query->query( $args );
+    $forms        = array_map( 'hf_get_form', $posts );
+    return $forms;
 }
 
 /**
@@ -29,74 +29,74 @@ function hf_get_forms( array $args = array() ) {
  */
 function hf_get_form( $form_id_or_slug ) {
 
-	if ( is_numeric( $form_id_or_slug ) || $form_id_or_slug instanceof WP_Post ) {
-		$post = get_post( $form_id_or_slug );
+    if ( is_numeric( $form_id_or_slug ) || $form_id_or_slug instanceof WP_Post ) {
+        $post = get_post( $form_id_or_slug );
 
-		if ( ! $post instanceof WP_Post || $post->post_type !== 'html-form' ) {
-			throw new Exception( 'Invalid form ID' );
-		}
-	} else {
+        if ( ! $post instanceof WP_Post || $post->post_type !== 'html-form' ) {
+            throw new Exception( 'Invalid form ID' );
+        }
+    } else {
 
-		$query = new WP_Query;
-		$posts = $query->query(
-			array(
-				'post_type'           => 'html-form',
-				'name'                => $form_id_or_slug,
-				'post_status'         => 'publish',
-				'posts_per_page'      => 1,
-				'ignore_sticky_posts' => true,
-				'no_found_rows'       => true,
-			)
-		);
-		if ( empty( $posts ) ) {
-			throw new Exception( 'Invalid form slug' );
-		}
-		$post = $posts[0];
-	}
+        $query = new WP_Query;
+        $posts = $query->query(
+            array(
+                'post_type'           => 'html-form',
+                'name'                => $form_id_or_slug,
+                'post_status'         => 'publish',
+                'posts_per_page'      => 1,
+                'ignore_sticky_posts' => true,
+                'no_found_rows'       => true,
+            )
+        );
+        if ( empty( $posts ) ) {
+            throw new Exception( 'Invalid form slug' );
+        }
+        $post = $posts[0];
+    }
 
-	// get all post meta in a single call for performance
-	$post_meta = get_post_meta( $post->ID );
+    // get all post meta in a single call for performance
+    $post_meta = get_post_meta( $post->ID );
 
-	// grab & merge form settings
-	$default_settings = array(
-		'save_submissions'   => 1,
-		'hide_after_success' => 0,
-		'redirect_url'       => '',
-		'required_fields'    => '',
-		'email_fields'       => '',
-	);
-	$default_settings = apply_filters( 'hf_form_default_settings', $default_settings );
-	$settings         = array();
-	if ( ! empty( $post_meta['_hf_settings'][0] ) ) {
-		$settings = (array) maybe_unserialize( $post_meta['_hf_settings'][0] );
-	}
-	$settings = array_merge( $default_settings, $settings );
+    // grab & merge form settings
+    $default_settings = array(
+        'save_submissions'   => 1,
+        'hide_after_success' => 0,
+        'redirect_url'       => '',
+        'required_fields'    => '',
+        'email_fields'       => '',
+    );
+    $default_settings = apply_filters( 'hf_form_default_settings', $default_settings );
+    $settings         = array();
+    if ( ! empty( $post_meta['_hf_settings'][0] ) ) {
+        $settings = (array) maybe_unserialize( $post_meta['_hf_settings'][0] );
+    }
+    $settings = array_merge( $default_settings, $settings );
 
-	// grab & merge form messages
-	$default_messages = array(
-		'success'                => __( 'Thank you! We will be in touch soon.', 'html-forms' ),
-		'invalid_email'          => __( 'Sorry, that email address looks invalid.', 'html-forms' ),
-		'required_field_missing' => __( 'Please fill in the required fields.', 'html-forms' ),
-		'error'                  => __( 'Oops. An error occurred.', 'html-forms' ),
-	);
-	$default_messages = apply_filters( 'hf_form_default_messages', $default_messages );
-	$messages         = array();
-	foreach ( $post_meta as $meta_key => $meta_values ) {
-		if ( strpos( $meta_key, 'hf_message_' ) === 0 ) {
-			$message_key              = substr( $meta_key, strlen( 'hf_message_' ) );
-			$messages[ $message_key ] = (string) $meta_values[0];
-		}
-	}
-	$messages = array_merge( $default_messages, $messages );
+    // grab & merge form messages
+    $default_messages = array(
+        'success'                => __( 'Thank you! We will be in touch soon.', 'html-forms' ),
+        'invalid_email'          => __( 'Sorry, that email address looks invalid.', 'html-forms' ),
+        'required_field_missing' => __( 'Please fill in the required fields.', 'html-forms' ),
+        'error'                  => __( 'Oops. An error occurred.', 'html-forms' ),
+    );
+    $default_messages = apply_filters( 'hf_form_default_messages', $default_messages );
+    $messages         = array();
+    foreach ( $post_meta as $meta_key => $meta_values ) {
+        if ( strpos( $meta_key, 'hf_message_' ) === 0 ) {
+            $message_key              = substr( $meta_key, strlen( 'hf_message_' ) );
+            $messages[ $message_key ] = (string) $meta_values[0];
+        }
+    }
+    $messages = array_merge( $default_messages, $messages );
 
-	// finally, create form instance
-	$form           = new Form( $post->ID );
-	$form->title    = $post->post_title;
-	$form->slug     = $post->post_name;
-	$form->markup   = $post->post_content;
-	$form->settings = $settings;
-	$form->messages = $messages;
-	return $form;
+    // finally, create form instance
+    $form           = new Form( $post->ID );
+    $form->title    = $post->post_title;
+    $form->slug     = $post->post_name;
+    $form->markup   = $post->post_content;
+    $form->settings = $settings;
+    $form->messages = $messages;
+    return $form;
 }
 
 /**
@@ -105,21 +105,21 @@ function hf_get_form( $form_id_or_slug ) {
  * @return Submission[]
  */
 function hf_get_form_submissions( $form_id, array $args = array() ) {
-	$default_args = array(
-		'offset' => 0,
-		'limit'  => 1000,
-	);
-	$args         = array_merge( $default_args, $args );
+    $default_args = array(
+        'offset' => 0,
+        'limit'  => 1000,
+    );
+    $args         = array_merge( $default_args, $args );
 
-	global $wpdb;
-	$table       = $wpdb->prefix . 'hf_submissions';
-	$results     = $wpdb->get_results( $wpdb->prepare( "SELECT s.* FROM {$table} s WHERE s.form_id = %d ORDER BY s.submitted_at DESC LIMIT %d, %d;", $form_id, $args['offset'], $args['limit'] ), OBJECT_K );
-	$submissions = array();
-	foreach ( $results as $key => $object ) {
-		$submission          = Submission::from_object( $object );
-		$submissions[ $key ] = $submission;
-	}
-	return $submissions;
+    global $wpdb;
+    $table       = $wpdb->prefix . 'hf_submissions';
+    $results     = $wpdb->get_results( $wpdb->prepare( "SELECT s.* FROM {$table} s WHERE s.form_id = %d ORDER BY s.submitted_at DESC LIMIT %d, %d;", $form_id, $args['offset'], $args['limit'] ), OBJECT_K );
+    $submissions = array();
+    foreach ( $results as $key => $object ) {
+        $submission          = Submission::from_object( $object );
+        $submissions[ $key ] = $submission;
+    }
+    return $submissions;
 }
 
 /**
@@ -127,67 +127,67 @@ function hf_get_form_submissions( $form_id, array $args = array() ) {
  * @return Submission
  */
 function hf_get_form_submission( $submission_id ) {
-	global $wpdb;
-	$table      = $wpdb->prefix . 'hf_submissions';
-	$object     = $wpdb->get_row( $wpdb->prepare( "SELECT s.* FROM {$table} s WHERE s.id = %d;", $submission_id ), OBJECT );
-	$submission = Submission::from_object( $object );
-	return $submission;
+    global $wpdb;
+    $table      = $wpdb->prefix . 'hf_submissions';
+    $object     = $wpdb->get_row( $wpdb->prepare( "SELECT s.* FROM {$table} s WHERE s.id = %d;", $submission_id ), OBJECT );
+    $submission = Submission::from_object( $object );
+    return $submission;
 }
 /**
  * @return array
  */
 function hf_get_settings() {
-	$default_settings = array(
-		'load_stylesheet' => 0,
-	);
+    $default_settings = array(
+        'load_stylesheet' => 0,
+    );
 
-	$settings = get_option( 'hf_settings', null );
+    $settings = get_option( 'hf_settings', null );
 
-	// prevent a SQL query when option does not yet exist
-	if ( $settings === null ) {
-		update_option( 'hf_settings', array(), true );
-		$settings = array();
-	}
+    // prevent a SQL query when option does not yet exist
+    if ( $settings === null ) {
+        update_option( 'hf_settings', array(), true );
+        $settings = array();
+    }
 
-	// merge with default settings
-	$settings = array_merge( $default_settings, $settings );
+    // merge with default settings
+    $settings = array_merge( $default_settings, $settings );
 
-	/**
-	* Filters the global HTML Forms hf_settings
-	*
-	* @param array $settings
-	*/
-	$settings = apply_filters( 'hf_settings', $settings );
+    /**
+     * Filters the global HTML Forms hf_settings
+     *
+     * @param array $settings
+     */
+    $settings = apply_filters( 'hf_settings', $settings );
 
-	return $settings;
+    return $settings;
 }
 
 /**
-* Get element from array, allows for dot notation eg: "foo.bar"
-*
-* @param array $array
-* @param string $key
-* @param mixed $default
-* @return mixed
-*/
+ * Get element from array, allows for dot notation eg: "foo.bar"
+ *
+ * @param array $array
+ * @param string $key
+ * @param mixed $default
+ * @return mixed
+ */
 function hf_array_get( $array, $key, $default = null ) {
-	if ( is_null( $key ) ) {
-		return $array;
-	}
+    if ( is_null( $key ) ) {
+        return $array;
+    }
 
-	if ( isset( $array[ $key ] ) ) {
-		return $array[ $key ];
-	}
+    if ( isset( $array[ $key ] ) ) {
+        return $array[ $key ];
+    }
 
-	foreach ( explode( '.', $key ) as $segment ) {
-		if ( ! is_array( $array ) || ! array_key_exists( $segment, $array ) ) {
-			return $default;
-		}
+    foreach ( explode( '.', $key ) as $segment ) {
+        if ( ! is_array( $array ) || ! array_key_exists( $segment, $array ) ) {
+            return $default;
+        }
 
-		$array = $array[ $segment ];
-	}
+        $array = $array[ $segment ];
+    }
 
-	return $array;
+    return $array;
 }
 
 /**
@@ -198,42 +198,42 @@ function hf_array_get( $array, $key, $default = null ) {
  * @return string
  */
 function hf_template( $template ) {
-	$replacers = new HTML_Forms\TagReplacers();
-	$tags      = array(
-		'user'       => array( $replacers, 'user' ),
-		'post'       => array( $replacers, 'post' ),
-		'url_params' => array( $replacers, 'url_params' ),
-	);
+    $replacers = new HTML_Forms\TagReplacers();
+    $tags      = array(
+        'user'       => array( $replacers, 'user' ),
+        'post'       => array( $replacers, 'post' ),
+        'url_params' => array( $replacers, 'url_params' ),
+    );
 
-	/**
-	* Filters the available tags in HTML Forms templates, like {{user.user_email}}.
-	*
-	* Can be used to add simple scalar replacements or more advanced replacement functions that accept a parameter.
-	*
-	* @param array $tags
-	*/
-	$tags = apply_filters( 'hf_template_tags', $tags );
+    /**
+     * Filters the available tags in HTML Forms templates, like {{user.user_email}}.
+     *
+     * Can be used to add simple scalar replacements or more advanced replacement functions that accept a parameter.
+     *
+     * @param array $tags
+     */
+    $tags = apply_filters( 'hf_template_tags', $tags );
 
-	$template = preg_replace_callback(
-		'/\{\{ *(\w+)(?:\.([\w\.]+))? *(?:\|\| *(\w+))? *\}\}/',
-		function( $matches ) use ( $tags ) {
-			$tag     = $matches[1];
-			$param   = ! isset( $matches[2] ) ? '' : $matches[2];
-			$default = ! isset( $matches[3] ) ? '' : $matches[3];
+    $template = preg_replace_callback(
+        '/\{\{ *(\w+)(?:\.([\w\.]+))? *(?:\|\| *(\w+))? *\}\}/',
+        function( $matches ) use ( $tags ) {
+            $tag     = $matches[1];
+            $param   = ! isset( $matches[2] ) ? '' : $matches[2];
+            $default = ! isset( $matches[3] ) ? '' : $matches[3];
 
-			// do not change anything if we have no replacer with that key, could be custom user logic or another plugin.
-			if ( ! isset( $tags[ $tag ] ) ) {
-				return $matches[0];
-			}
+            // do not change anything if we have no replacer with that key, could be custom user logic or another plugin.
+            if ( ! isset( $tags[ $tag ] ) ) {
+                return $matches[0];
+            }
 
-			$replacement = $tags[ $tag ];
-			$value       = is_callable( $replacement ) ? call_user_func_array( $replacement, array( $param ) ) : $replacement;
-			return ! empty( $value ) ? $value : $default;
-		},
-		$template
-	);
+            $replacement = $tags[ $tag ];
+            $value       = is_callable( $replacement ) ? call_user_func_array( $replacement, array( $param ) ) : $replacement;
+            return ! empty( $value ) ? $value : $default;
+        },
+        $template
+    );
 
-	return $template;
+    return $template;
 }
 
 /**
@@ -243,113 +243,133 @@ function hf_template( $template ) {
  * @return string
  */
 function hf_replace_data_variables( $string, $data = array(), $escape_function = null ) {
-	$string = preg_replace_callback(
-		'/\[([a-zA-Z0-9\-\._]+)\]/',
-		function( $matches ) use ( $data, $escape_function ) {
-			$key         = $matches[1];
-			$replacement = hf_array_get( $data, $key, '' );
-			$replacement = hf_field_value( $replacement, 0, $escape_function );
-			return $replacement;
-		},
-		$string
-	);
-	return $string;
+    $string = preg_replace_callback(
+        '/\[([a-zA-Z0-9\-\._]+)\]/',
+        function( $matches ) use ( $data, $escape_function ) {
+            $key         = $matches[1];
+            $replacement = hf_array_get( $data, $key, '' );
+            $replacement = hf_field_value( $replacement, 0, $escape_function );
+            return $replacement;
+        },
+        $string
+    );
+    return $string;
 }
 
 /**
-* Returns a formatted & HTML-escaped field value. Detects file-, array- and date-types.
-*
-* Caveat: if value is a file, an HTML string is returned (which means email action should use "Content-Type: html" when it includes a file field).
-*
-* @param string|array $value
-* @param int $limit
-* @param Closure|string $escape_function
-* @return string
-* @since 1.3.1
-*/
+ * Returns a formatted & HTML-escaped field value. Detects file-, array- and date-types.
+ *
+ * Caveat: if value is a file, an HTML string is returned (which means email action should use "Content-Type: html" when it includes a file field).
+ *
+ * @param string|array $value
+ * @param int $limit
+ * @param Closure|string $escape_function
+ * @return string
+ * @since 1.3.1
+ */
 function hf_field_value( $value, $limit = 0, $escape_function = 'esc_html' ) {
-	if ( $value === '' ) {
-		return $value;
-	}
+    if ( $value === '' ) {
+        return $value;
+    }
 
-	if ( hf_is_file( $value ) ) {
-		$file_url = isset( $value['url'] ) ? $value['url'] : '';
-		if ( isset( $value['attachment_id'] ) ) {
-			$file_url = admin_url( sprintf( 'post.php?action=edit&post=%d', $value['attachment_id'] ) );
-		}
-		$short_name = substr( $value['name'], 0, 20 );
-		$suffix     = strlen( $value['name'] ) > 20 ? '...' : '';
-		return sprintf( '<a href="%s">%s%s</a> (%s)', esc_attr( $file_url ), esc_html( $short_name ), esc_html( $suffix ), hf_human_filesize( $value['size'] ) );
-	}
+    if ( hf_is_file( $value ) ) {
+        $file_url = isset( $value['url'] ) ? $value['url'] : '';
+        if ( isset( $value['attachment_id'] ) ) {
+            $file_url = admin_url( sprintf( 'post.php?action=edit&post=%d', $value['attachment_id'] ) );
+        }
+        $short_name = substr( $value['name'], 0, 20 );
+        $suffix     = strlen( $value['name'] ) > 20 ? '...' : '';
+        return sprintf( '<a href="%s">%s%s</a> (%s)', esc_attr( $file_url ), esc_html( $short_name ), esc_html( $suffix ), hf_human_filesize( $value['size'] ) );
+    }
 
-	if ( hf_is_date( $value ) ) {
-		$date_format = get_option( 'date_format' );
-		return gmdate( $date_format, strtotime( $value ) );
-	}
+    if ( hf_is_date( $value ) ) {
+        $date_format = get_option( 'date_format' );
+        return gmdate( $date_format, strtotime( $value ) );
+    }
 
-	// join array-values with comma
-	if ( is_array( $value ) ) {
-		$value = join( ', ', $value );
-	}
+    // join array-values with comma
+    if ( is_array( $value ) ) {
+        $value = join( ', ', $value );
+    }
 
-	// limit string to certain length
-	if ( $limit > 0 ) {
-		$limited = strlen( $value ) > $limit;
-		$value   = substr( $value, 0, $limit );
+    // limit string to certain length
+    if ( $limit > 0 ) {
+        $limited = strlen( $value ) > $limit;
+        $value   = substr( $value, 0, $limit );
 
-		if ( $limited ) {
-			$value .= '...';
-		}
-	}
+        if ( $limited ) {
+            $value .= '...';
+        }
+    }
 
-	// escape value
-	if ( $escape_function !== null && is_callable( $escape_function ) ) {
-		$value = $escape_function( $value );
-	}
+    // escape value
+    if ( $escape_function !== null && is_callable( $escape_function ) ) {
+        $value = $escape_function( $value );
+    }
 
-	return $value;
+    return $value;
 }
 
 /**
-* Returns true if value is a "file"
-*
-* @param mixed $value
-* @return bool
-*/
+ * Returns true if value is a "file"
+ *
+ * @param mixed $value
+ * @return bool
+ */
 function hf_is_file( $value ) {
-	return is_array( $value )
-		&& isset( $value['name'] )
-		&& isset( $value['size'] )
-		&& isset( $value['type'] );
+    return is_array( $value )
+           && isset( $value['name'] )
+           && isset( $value['size'] )
+           && isset( $value['type'] );
 }
 
 /**
-* Returns true if value looks like a date-string submitted from a <input type="date">
-* @param mixed $value
-* @return bool
-* @since 1.3.1
-*/
+ * Returns true if value looks like a date-string submitted from a <input type="date">
+ * @param mixed $value
+ * @return bool
+ * @since 1.3.1
+ */
 function hf_is_date( $value ) {
 
-	if ( ! is_string( $value )
-			|| strlen( $value ) !== 10
-			|| (int) preg_match( '/\d{2,4}[-\/]\d{2}[-\/]\d{2,4}/', $value ) === 0 ) {
-		return false;
-	}
+    if ( ! is_string( $value )
+         || strlen( $value ) !== 10
+         || (int) preg_match( '/\d{2,4}[-\/]\d{2}[-\/]\d{2,4}/', $value ) === 0 ) {
+        return false;
+    }
 
-	$timestamp = strtotime( $value );
-	return $timestamp != false;
+    $timestamp = strtotime( $value );
+    return $timestamp != false;
 }
 
 /**
  * @param int $size
  * @param int $precision
  * @return string
-*/
+ */
 function hf_human_filesize( $size, $precision = 2 ) {
-	for ( $i = 0; ( $size / 1024 ) > 0.9; $i++, $size /= 1024 ) {
-		// nothing, loop logic contains everything
-	}
-	$steps = array( 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' );
-	return round( $size, $precision ) . $steps[ $i ];
+    for ( $i = 0; ( $size / 1024 ) > 0.9; $i++, $size /= 1024 ) {
+        // nothing, loop logic contains everything
+    }
+    $steps = array( 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' );
+    return round( $size, $precision ) . $steps[ $i ];
+}
+
+
+/**
+ * Gets all the form tabs to show in the admin.
+ * @param Form $form
+ * @return array
+ */
+function hf_get_admin_tabs(Form $form){
+    $tabs = array(
+        'fields'        => __( 'Fields', 'html-forms' ),
+        'messages'      => __( 'Messages', 'html-forms' ),
+        'settings'      => __( 'Settings', 'html-forms' ),
+        'actions'       => __( 'Actions', 'html-forms' ),
+    );
+
+    if( $form->settings['save_submissions'] ) {
+        $tabs['submissions'] = __( 'Submissions', 'html-forms' );
+    }
+    return apply_filters('hf_admin_tabs', $tabs, $form);
 }

--- a/views/page-edit-form.php
+++ b/views/page-edit-form.php
@@ -12,7 +12,74 @@ if( $form->settings['save_submissions'] ) {
 }
 
 ?>
-<script>document.title = 'Edit form' + ' - ' + document.title;</script>
+<script>docu<?php defined( 'ABSPATH' ) or exit;
+
+    $tabs = hf_get_admin_tabs($form);
+
+    ?>
+	<script>document.title = 'Edit form' + ' - ' + document.title;</script>
+<div class="wrap hf">
+
+    <p class="breadcrumbs">
+        <span class="prefix"><?php echo __( 'You are here: ', 'html-forms' ); ?></span>
+        <a href="<?php echo admin_url( 'admin.php?page=html-forms' ); ?>">HTML Forms</a> &rsaquo;
+        <span class="current-crumb"><strong><?php _e( 'Edit form', 'html-forms' ); ?></strong></span>
+    </p>
+
+    <h1 class="page-title"><?php _e( 'Edit form', 'html-forms' ); ?></h1>
+
+    <?php if ( ! empty( $_GET['saved'] ) ) {
+        echo '<div class="notice notice-success"><p>' . __( 'Form updated.', 'html-forms' ) . '</p></div>';
+    } ?>
+
+    <form method="post">
+        <input type="hidden" name="_hf_admin_action" value="save_form" />
+        <input type="hidden" name="form_id" value="<?php echo esc_attr( $form->ID ); ?>" />
+        <input type="submit" style="display: none; " />
+
+        <div id="titlediv">
+            <div id="titlewrap">
+                <label for="title"><?php _e( 'Form title', 'html-forms' ); ?></label>
+                <input type="text" name="form[title]" size="30" value="<?php echo esc_attr( $form->title ); ?>" id="title" spellcheck="true" autocomplete="off" placeholder="<?php echo __( "Enter the title of your form", 'html-forms' ); ?>" style="line-height: initial;" >
+            </div>
+            <div class="inside" style="margin-top: 3px;">
+                <div class="hf-tiny-margin hide-if-no-js">
+                    <strong>Slug:</strong> <input type="text" id="form-slug-input" name="form[slug]" value="<?php echo esc_attr( $form->slug ); ?>" readonly /> &lrm;<button type="button" class="button button-small" onclick="document.getElementById('form-slug-input').removeAttribute('readonly');" aria-label="<?php _e( 'Edit slug', 'html-forms' ); ?>"><?php _e( 'Edit', 'html-forms' ); ?></button>
+                </div>
+                <div class="hf-tiny-margin">
+                    <label for="shortcode"><?php _e( 'Copy this shortcode and paste it into your post, page, or text widget content:', 'html-forms' ); ?></label><br />
+                    <input id="shortcode" type="text" class="regular-text" value="<?php echo esc_attr( sprintf( '[hf_form slug="%s"]', $form->slug ) ); ?>" readonly onclick="this.select()">
+                </div>
+            </div>
+        </div>
+
+        <div class="hf-small-margin">
+            <h2 class="nav-tab-wrapper" id="hf-tabs-nav">
+                <?php foreach( $tabs as $tab => $name ) {
+                    $class = ( $active_tab === $tab ) ? 'nav-tab-active' : '';
+                    echo sprintf( '<a class="nav-tab nav-tab-%s %s" data-tab-target="%s" href="%s">%s</a>', $tab, $class, $tab, $this->get_tab_url( $tab ), $name );
+                } ?>
+            </h2>
+
+            <div id="tabs">
+                <?php
+                // output each tab
+                foreach( $tabs as $tab => $name ) {
+                    $class = ($active_tab === $tab) ? 'hf-tab-active' : '';
+                    echo sprintf('<div class="hf-tab %s" id="tab-%s" data-tab="%s">', $class, $tab, $tab);
+                    do_action( 'hf_admin_output_form_tab_' . $tab, $form );
+                    echo '</div>';
+                } // end foreach tab
+                ?>
+
+            </div><!-- / tabs -->
+        </div>
+
+    </form>
+
+    <?php require __DIR__ . '/admin-footer.php'; ?>
+</div>
+ment.title = 'Edit form' + ' - ' + document.title;</script>
 <div class="wrap hf">
 
     <p class="breadcrumbs">


### PR DESCRIPTION
I'm making an add-on to add a tab that I'm calling "charts" which shows graphs of folks' common answers and answeers for each submission grouped by the form field.
And I just needed a way to add the tab.
There are two spots I saw make the list of tabs, and got them to instead use a new common function `hf_get_admin_tabs`, and put the filter in there.

So this is how I'm adding a tab:

```
use HTML_Forms\Form;

add_filter('hf_admin_tabs',function($tabs){
    $tabs['charts'] = esc_html__('Charts', 'hfc');
    return $tabs;
});
add_action(
    'hf_admin_output_form_tab_charts',
    function(Form $form){
        // echo out the HTML for my charts tab
    },
    10,
    1
);
```

What do you think?