### PR TITLE
add and use hf_get_admin_tabs and filter its result

### DIFF
--- a/src/admin/class-table.php
+++ b/src/admin/class-table.php
@@ -164,12 +164,7 @@ if ( class_exists( 'WP_List_Table' ) ) {
 			$title     = '<strong><a class="row-title" href="' . $edit_link . '">' . esc_html( $form->title ) . '</a></strong>';
 
 			$actions = array();
-			$tabs    = array(
-				'fields'   => __( 'Fields', 'html-forms' ),
-				'messages' => __( 'Messages', 'html-forms' ),
-				'settings' => __( 'Settings', 'html-forms' ),
-				'actions'  => __( 'Actions', 'html-forms' ),
-			);
+			$tabs = hf_get_admin_tabs($form);
 
 			if ( $form->settings['save_submissions'] ) {
 				$tabs['submissions'] = __( 'Submissions', 'html-forms' );

--- a/src/functions.php
+++ b/src/functions.php
@@ -353,3 +353,22 @@ function hf_human_filesize( $size, $precision = 2 ) {
 	$steps = array( 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' );
 	return round( $size, $precision ) . $steps[ $i ];
 }
+
+/**
+ * Gets all the form tabs to show in the admin.
+ * @param Form $form
+ * @return array
+ */
+function hf_get_admin_tabs(Form $form){
+	$tabs = array(
+		'fields'        => __( 'Fields', 'html-forms' ),
+		'messages'      => __( 'Messages', 'html-forms' ),
+		'settings'      => __( 'Settings', 'html-forms' ),
+		'actions'       => __( 'Actions', 'html-forms' ),
+	);
+
+	if( $form->settings['save_submissions'] ) {
+		$tabs['submissions'] = __( 'Submissions', 'html-forms' );
+	}
+	return apply_filters('hf_admin_tabs', $tabs, $form);
+}

--- a/views/page-edit-form.php
+++ b/views/page-edit-form.php
@@ -1,15 +1,6 @@
 <?php defined( 'ABSPATH' ) or exit;
 
-$tabs = array(
-    'fields'        => __( 'Fields', 'html-forms' ),
-    'messages'      => __( 'Messages', 'html-forms' ),
-    'settings'      => __( 'Settings', 'html-forms' ),
-    'actions'       => __( 'Actions', 'html-forms' ),
-);
-
-if( $form->settings['save_submissions'] ) {
-    $tabs['submissions'] = __( 'Submissions', 'html-forms' );
-}
+$tabs = hf_get_admin_tabs($form);
 
 ?>
 <script>document.title = 'Edit form' + ' - ' + document.title;</script>


### PR DESCRIPTION
I'm making an add-on to add a tab that I'm calling "charts" which shows graphs of folks' common answers and answeers for each submission grouped by the form field.
And I just needed a way to add the tab.
There are two spots I saw make the list of tabs, and got them to instead use a new common function `hf_get_admin_tabs`, and put the filter in there.

So this is how I'm adding a tab:

```
use HTML_Forms\Form;

add_filter('hf_admin_tabs',function($tabs){
    $tabs['charts'] = esc_html__('Charts', 'hfc');
    return $tabs;
});
add_action(
    'hf_admin_output_form_tab_charts',
    function(Form $form){
        // echo out the HTML for my charts tab
    },
    10,
    1
);
```

What do you think?