### PR TITLE
Use WordPress' default collation when creating the submissions table

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -3,12 +3,6 @@
 use HTML_Forms\Form;
 use HTML_Forms\Submission;
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
-
-require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-
 /**
  * @param array $args
  * @return array
@@ -444,6 +438,7 @@ function _hf_create_submissions_table() {
         `submitted_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) {$charset_collate};";
 	
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 	dbDelta( $sql );
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -428,7 +428,8 @@ function _hf_create_submissions_table() {
 
 	// create table for storing submissions
 	$table = $wpdb->prefix . 'hf_submissions';
-	$sql = "CREATE TABLE {$table}(
+	$wpdb->query(
+		"CREATE TABLE IF NOT EXISTS {$table}(
         `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
         `form_id` INT UNSIGNED NOT NULL,
         `data` TEXT NOT NULL,
@@ -436,10 +437,8 @@ function _hf_create_submissions_table() {
         `ip_address` VARCHAR(255) NULL,
         `referer_url` TEXT NULL,
         `submitted_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-) {$charset_collate};";
-	
-	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-	dbDelta( $sql );
+) {$charset_collate};"
+	);
 }
 
 function _hf_on_add_user_to_blog( $user_id, $role, $blog_id ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -427,7 +427,6 @@ function _hf_on_plugin_activation_multisite() {
 
 // install table for main site on regular installs, or active site for multisite
 function _hf_create_submissions_table() {
-	
 	/** @var wpdb */
 	global $wpdb;
 	

--- a/src/functions.php
+++ b/src/functions.php
@@ -3,6 +3,12 @@
 use HTML_Forms\Form;
 use HTML_Forms\Submission;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
 /**
  * @param array $args
  * @return array
@@ -421,13 +427,15 @@ function _hf_on_plugin_activation_multisite() {
 
 // install table for main site on regular installs, or active site for multisite
 function _hf_create_submissions_table() {
+	
 	/** @var wpdb */
 	global $wpdb;
+	
+	$charset_collate = $wpdb->get_charset_collate();
 
 	// create table for storing submissions
 	$table = $wpdb->prefix . 'hf_submissions';
-	$wpdb->query(
-		"CREATE TABLE IF NOT EXISTS {$table}(
+	$sql = "CREATE TABLE {$table}(
         `id` INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
         `form_id` INT UNSIGNED NOT NULL,
         `data` TEXT NOT NULL,
@@ -435,8 +443,9 @@ function _hf_create_submissions_table() {
         `ip_address` VARCHAR(255) NULL,
         `referer_url` TEXT NULL,
         `submitted_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=INNODB CHARACTER SET={$wpdb->charset};"
-	);
+) {$charset_collate};";
+	
+	dbDelta( $sql );
 }
 
 function _hf_on_add_user_to_blog( $user_id, $role, $blog_id ) {


### PR DESCRIPTION
When the `hf_submissions` table is created it's picking up the default server collation which is often different to the utf8 collation other Wordpress tables use. MySQL 8.0 has a default server collation of `utf8mb4_0900_ai_ci` and this can cause an `Unknown collation utf8mb4_0900_ai_ci` error when trying to export and then import the database in to a different server environment such as MariaDB which doesn't recognise it.

Using `$wpdb->get_charset_collate()` fixes this by returning the same utf8 collation Wordpress uses for its default tables.
For reference [here's  how Wordpress is currently creating the default tables](https://github.com/WordPress/WordPress/blob/da4456672cf1ac9793ae9171290c1a7638edd0b7/wp-admin/includes/schema.php) and the [dbDelta function](https://developer.wordpress.org/reference/functions/dbdelta/) will check whether the table exists or not.

Thank you for the plugin it's great for developers to use.