### PR TITLE
Improve get_field_count

### DIFF
--- a/src/class-form.php
+++ b/src/class-form.php
@@ -181,7 +181,9 @@ class Form {
 	* @return int The number of named fields in the form
 	*/
 	public function get_field_count() {
-		$count = substr_count( strtolower( $this->get_html() ), ' name=' );
+		$pattern = '/\bname\s*=\s*["\']/i';
+		preg_match_all($pattern, strtolower( $this->get_html() ), $matches);
+		$count = count($matches[0]);
 		$count++; // Add one for 'was-required'
 		return $count;
 	}


### PR DESCRIPTION
A small improvement. 

The function `get_field_count` is used to count the number of named fields in a form. It is used ensure that not more fields are submitted to prevent spam.

Currently the function counts the occurrence of the substring " name=" in a form. But I encountered an error with this approach while using Prettier to format the html of my forms. Prettier adds line breaks, so there is no space before the name attribute and form submission fails. 

I replaced the simple substring count with a simple regex pattern. I think the performance impact of the additional regex is negligible.

In this version, \b is used to assert word boundaries, ensuring that "name" is not part of a larger word. The \s* parts account for optional spaces, and the ["\'] part looks for a quote (single or double) immediately after the equal sign. (Explanation done by ChatGPT.)